### PR TITLE
Clean up the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
 
 		<imglib2.version>5.8.0</imglib2.version>
+		<zip4j.version>1.3.2</zip4j.version>
 	</properties>
 
 	<repositories>
@@ -150,7 +151,7 @@
 		<dependency>
 			<groupId>net.lingala.zip4j</groupId>
 			<artifactId>zip4j</artifactId>
-			<version>1.3.2</version>
+			<version>${zip4j.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -91,13 +89,6 @@
 		<zip4j.version>1.3.2</zip4j.version>
 	</properties>
 
-	<repositories>
-		<repository>
-			<id>scijava.public</id>
-			<url>https://maven.scijava.org/content/groups/public</url>
-		</repository>
-	</repositories>
-
 	<dependencies>
 		<!-- ImageJ dependencies -->
 		<dependency>
@@ -171,5 +162,10 @@
 		</dependency>
 	</dependencies>
 
+	<repositories>
+		<repository>
+			<id>scijava.public</id>
+			<url>https://maven.scijava.org/content/groups/public</url>
+		</repository>
+	</repositories>
 </project>
-

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>27.0.1</version>
 	</parent>
 
 	<groupId>sc.fiji</groupId>
@@ -99,7 +99,6 @@
 	</repositories>
 
 
-
 	<dependencies>
 		<dependency>
 			<groupId>io.scif</groupId>
@@ -118,27 +117,12 @@
 			<artifactId>jai-codec</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>loci</groupId>
-			<artifactId>loci-common</artifactId>
-			<version>4.4.9</version>
+			<groupId>org.openmicroscopy</groupId>
+			<artifactId>ome-common</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>loci</groupId>
-			<artifactId>loci_plugins</artifactId>
-			<version>4.4.9</version>
-
-
-			<!-- These cause verification errors (duplicate classes) -->
-			<exclusions>
-				<exclusion>
-					<groupId>edu.ucar</groupId>
-					<artifactId>udunits</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>edu.ucar</groupId>
-					<artifactId>netcdf</artifactId>
-				</exclusion>
-			</exclusions>
+			<groupId>ome</groupId>
+			<artifactId>bio-formats_plugins</artifactId>
 		</dependency>
 
 		<!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,7 @@
 		<package-name>sc.fiji.simplifiedio</package-name>
 		<license.licenseName>gpl_v3</license.licenseName>
 		<license.copyrightOwners>Fiji developers.</license.copyrightOwners>
-		<license.projectName>Fiji distribution of ImageJ for the life
-			sciences.</license.projectName>
+		<license.projectName>Fiji distribution of ImageJ for the life sciences.</license.projectName>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
 	</ciManagement>
 
 	<properties>
-		<package-name>sc.fiji.simplified-io</package-name>
+		<package-name>sc.fiji.simplifiedio</package-name>
 		<license.licenseName>gpl_v3</license.licenseName>
 		<license.copyrightOwners>Fiji developers.</license.copyrightOwners>
 		<license.projectName>Fiji distribution of ImageJ for the life

--- a/pom.xml
+++ b/pom.xml
@@ -98,34 +98,56 @@
 		</repository>
 	</repositories>
 
-
 	<dependencies>
+		<!-- ImageJ dependencies -->
 		<dependency>
-			<groupId>io.scif</groupId>
-			<artifactId>scifio</artifactId>
+			<groupId>net.imagej</groupId>
+			<artifactId>ij</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-common</artifactId>
+		</dependency>
+
+		<!-- ImgLib2 dependencies -->
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-ij</artifactId>
 		</dependency>
+
+		<!-- SciJava dependencies -->
 		<dependency>
-			<groupId>javax.media</groupId>
-			<artifactId>jai-core</artifactId>
+			<groupId>org.scijava</groupId>
+			<artifactId>scijava-common</artifactId>
 		</dependency>
+
+		<!-- SCIFIO dependencies -->
 		<dependency>
-			<groupId>com.sun.media</groupId>
-			<artifactId>jai-codec</artifactId>
+			<groupId>io.scif</groupId>
+			<artifactId>scifio</artifactId>
 		</dependency>
+
+		<!-- OME dependencies -->
 		<dependency>
-			<groupId>org.openmicroscopy</groupId>
-			<artifactId>ome-common</artifactId>
+			<groupId>ome</groupId>
+			<artifactId>formats-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>ome</groupId>
 			<artifactId>bio-formats_plugins</artifactId>
 		</dependency>
 
-		<!-- Test dependencies -->
+		<!-- Third party dependencies -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+		</dependency>
+
+		<!-- Test scope dependencies -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>


### PR DESCRIPTION
This branch updates the POM to have clean dependencies, with current SciJava project best practices.